### PR TITLE
Modified METIS to allow compilation with Intel oneAPI on Windows

### DIFF
--- a/metis-5.1.0/BUILD-Windows.txt
+++ b/metis-5.1.0/BUILD-Windows.txt
@@ -43,3 +43,19 @@ Studio. If the configuration is not already "Release", set it to
 <BINARY_DIR>\programs\Release. (<BINARY_DIR> will be build\windows if
 you used the command line or whatever you choose if using the CMake
 GUI.)
+
+
+Using the Intel oneAPI framework
+--------------------------------
+
+It is possible to use the Intel oneAPI framework, which provides the 
+Intel C and C++ compilers as well as other development tools.
+
+Open the command prompt and cd to the METIS source directory. Run
+
+	> mkdir build\windows-intel
+	> cd build\windows-intel
+	> cmake -G "Ninja" -DCMAKE_C_COMPILER=icl.exe -DCMAKE_CXX_COMPILER=icl.exe ../..
+	> ninja.exe
+
+to generate the build files and compile the project

--- a/metis-5.1.0/GKlib/gk_arch.h
+++ b/metis-5.1.0/GKlib/gk_arch.h
@@ -60,7 +60,9 @@ typedef ptrdiff_t ssize_t;
 
 #ifdef __MSC__
 /* MSC does not have rint() function */
+#ifndef __ICL
 #define rint(x) ((int)((x)+0.5))  
+#endif
 
 /* MSC does not have INFINITY defined */
 #ifndef INFINITY

--- a/metis-5.1.0/libmetis/metislib.h
+++ b/metis-5.1.0/libmetis/metislib.h
@@ -32,10 +32,12 @@
 
 
 #if defined(COMPILER_MSC)
+#if not defined(__ICL)
 #if defined(rint)
   #undef rint
 #endif
 #define rint(x) ((idx_t)((x)+0.5))  /* MSC does not have rint() function */
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
Minor modifications to allow the compilation of METIS 5.1.0 on Windows using all tools from the Intel oneAPI suite.

- Prevented "rint" to be redefined on Windows when the Intel compiler is used
- Modified BUILD-Windows.txt to show how to compile with the Intel oneAPI suite

Tested on Windows 10 with Intel oneAPI 20.2.1.20201112
