### PR TITLE
Eliminate compiler warnings

### DIFF
--- a/src/GKlib/csr.c
+++ b/src/GKlib/csr.c
@@ -1361,15 +1361,15 @@ void gk_csr_Normalize(gk_csr_t *mat, int what, int norm)
     #pragma omp for private(j,sum) schedule(static)
       for (i=0; i<n; i++) {
         for (sum=0.0, j=ptr[i]; j<ptr[i+1]; j++)
-  	if (norm == 2)
-  	  sum += val[j]*val[j];
-  	else if (norm == 1)
-  	  sum += val[j]; 
+  	  if (norm == 2)
+  	    sum += val[j]*val[j];
+  	  else if (norm == 1)
+  	    sum += val[j]; 
         if (sum > 0) {
-  	if (norm == 2)
-  	  sum=1.0/sqrt(sum); 
-  	else if (norm == 1)
-  	  sum=1.0/sum; 
+  	  if (norm == 2)
+  	    sum=1.0/sqrt(sum); 
+  	  else if (norm == 1)
+  	    sum=1.0/sum; 
           for (j=ptr[i]; j<ptr[i+1]; j++)
             val[j] *= sum;
         }


### PR DESCRIPTION
The indentation of the code is misleading as to what is or isn't part of the preceding if's and for's.  

Fix the indentation to match how the compiler will interpret the code.  Would be better to use explicit open/close braces, but this is the minimal change to eliminate compiler warnings.