### PR TITLE
Eliminate compiler warnings

### DIFF
--- a/src/GKlib/getopt.c
+++ b/src/GKlib/getopt.c
@@ -342,9 +342,9 @@ static int gk_getopt_internal(int argc, char **argv, char *optstring,
   if (gk_optind == 0 || !gk_getopt_initialized) {
     if (gk_optind == 0)
       gk_optind = 1;	/* Don't scan ARGV[0], the program name.  */
-      optstring = gk_getopt_initialize (argc, argv, optstring);
-      gk_getopt_initialized = 1;
-    }
+    optstring = gk_getopt_initialize (argc, argv, optstring);
+    gk_getopt_initialized = 1;
+  }
 
   /* Test whether ARGV[gk_optind] points to a non-option argument.
      Either it does not have option syntax, or there is an environment flag
@@ -700,7 +700,7 @@ static int gk_getopt_internal(int argc, char **argv, char *optstring,
 	else
 	  /* We already incremented `gk_optind' once; increment it again when taking next ARGV-elt as argument.  */
 	  gk_optarg = argv[gk_optind++];
-	  nextchar = NULL;
+	nextchar = NULL;
       }
     }
     return c;


### PR DESCRIPTION
The source code has some misleading indentation which does not match how the compiler will interpret the if's and else's.

Adjust indentation to match how the compiler will interpret the code.